### PR TITLE
Add arguments to choose the peer-observer repo

### DIFF
--- a/docker/bitcoin-node-entrypoint.sh
+++ b/docker/bitcoin-node-entrypoint.sh
@@ -47,4 +47,4 @@ fi
 
 echo "Starting ebpf-extractor"
 # Run ebpf-extractor as root (needs CAP_SYS_ADMIN for BPF)
-exec /usr/local/bin/ebpf-extractor --nats-address nats://nats:4222 --bitcoind-path /shared/bitcoind
+exec /usr/local/bin/ebpf-extractor --no-idle-exit --nats-address nats://nats:4222 --bitcoind-path /shared/bitcoind

--- a/docker/bitcoin-node.dockerfile
+++ b/docker/bitcoin-node.dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BTC_CORE_TAG=v29.0
+ARG PEER_EXTRACTOR_REPO=https://github.com/0xB10C/peer-observer.git
+ARG PEER_EXTRACTOR_BRANCH=master
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -36,7 +38,7 @@ RUN rustup default stable
 RUN rustup component add rustfmt
 
 # Copy the local repository to the container
-RUN git clone https://github.com/0xB10C/peer-observer.git /peer-observer
+RUN git clone -b $PEER_EXTRACTOR_BRANCH --single-branch $PEER_EXTRACTOR_REPO /peer-observer
 
 # Set working directory to the repository
 WORKDIR /peer-observer


### PR DESCRIPTION
This allows us to choose which fork of peer-observer tools to use:

```
docker compose build --build-arg PEER_EXTRACTOR_REPO=https://github.com/edilmedeiros/peer-observer.git --build-arg PEER_EXTRACTOR_BRANCH=opt-out-timer --no-cache
```

That way we can use the current infrastructure to test our own work. This is crucial for me because I can't run the ebpf-extractor on a mac.