### PR TITLE
Separate peer observer build from btc core build

### DIFF
--- a/docker/peer-observer-tools.dockerfile
+++ b/docker/peer-observer-tools.dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.87.0-slim-bookworm AS builder
 
+ARG PEER_EXTRACTOR_REPO=https://github.com/0xB10C/peer-observer.git
+ARG PEER_EXTRACTOR_BRANCH=master
+
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -9,8 +12,8 @@ RUN apt-get update && apt-get install -y \
 # Create a non-root user and configure sudo
 RUN useradd -m -s /bin/bash appuser
 
-# Copy the local repository to the container
-RUN git clone https://github.com/0xB10C/peer-observer.git
+# Copy repository to the container
+RUN git clone -b $PEER_EXTRACTOR_BRANCH --single-branch $PEER_EXTRACTOR_REPO /peer-observer
 RUN chown -R appuser:appuser /peer-observer
 USER appuser
 


### PR DESCRIPTION
Think this will make a big diff in github action run time from #13 , last time this action took almost 14 minutes.

closes #12 