### PR TITLE
Add monitoring only option - Bitcoin and ebpf-extractor already running

### DIFF
--- a/monitoring-only.yml
+++ b/monitoring-only.yml
@@ -1,0 +1,25 @@
+# Docker Compose configuration for monitoring services only
+# Use this when running Bitcoin node and ebpf-extractor externally
+#
+# Usage:
+#   docker compose -f monitoring-only.yml --profile monitoring up -d
+#
+# Configuration:
+#   LOCAL setup (monitoring on same machine as Bitcoin node):
+#     ./ebpf-extractor --nats-address nats://localhost:4222 --bitcoind-path /path/to/bitcoind
+#
+#   REMOTE setup (monitoring on different machine):
+#     ./ebpf-extractor --nats-address nats://MONITORING_SERVER_IP:4222 --bitcoind-path /path/to/bitcoind
+#
+# Security Note:
+#   NATS port 4222 is exposed. For remote setups, consider:
+#   - Firewall rules to restrict access
+#   - NATS authentication/TLS for production
+#   - VPN or SSH tunneling between machines
+
+include:
+  - path: docker-compose/nats.yml
+  - path: docker-compose/logger.yml
+  - path: docker-compose/connectivity-check.yml
+  - path: docker-compose/metrics.yml
+  - path: docker-compose/websocket.yml


### PR DESCRIPTION
I'm running this because I already have a Bitcoin node with the `ebpf-extractor` and `rpc-extractor` running alongside.

Might be useful for others too?