### PR TITLE
Add bitcoind-pid parameter to ebpf-extractor

### DIFF
--- a/docker/bitcoin-node-entrypoint.sh
+++ b/docker/bitcoin-node-entrypoint.sh
@@ -47,4 +47,8 @@ fi
 
 echo "Starting ebpf-extractor"
 # Run ebpf-extractor as root (needs CAP_SYS_ADMIN for BPF)
-exec /usr/local/bin/ebpf-extractor --no-idle-exit --nats-address nats://nats:4222 --bitcoind-path $BTC_BIN_PATH/bitcoind
+exec /usr/local/bin/ebpf-extractor \
+    --no-idle-exit \
+    --nats-address nats://nats:4222 \
+    --bitcoind-path "$BTC_BIN_PATH/bitcoind" \
+    --bitcoind-pid "$BITCOIND_PID"


### PR DESCRIPTION
Description: takes the `$BITCOIND_PID` value and pass it as `bitcoind-pid` parameter to the `ebpf-extractor` initialization command.

Expected results: `ebpf-extractor` initializes correctly and connects to the correct node.
<img width="1803" height="286" alt="image" src="https://github.com/user-attachments/assets/b0c446f7-b436-4fd6-bde6-29b97b660f23" />
